### PR TITLE
CONTRIBUTING.mdにテンプレのURLを入れる

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -106,10 +106,16 @@
 
 ## Pull Request
 - **作成ルール**
-  - 基本的にIssueに対してコードを作成し、プルリクエストを行う
+  - 基本的にIssueに対してブランチを作成し、プルリクエストを行う
 - **作成手順**
-  - テンプレートに沿って内容を作成
-    - [テンプレート](https://github.com/first-contributions-ja/first-contributions-ja.github.io/blob/main/.github/PULL_REQUEST_TEMPLATE%20/pr.md?plain=1)
+  - プルリクエスト作成画面のURL末尾に以下を追加する
+    ```markdown
+    ?quick_pull=1&template=pr.md
+    ```
+  - プルリク画面URL
+    - `https://github.com/first-contributions-ja/first-contributions-ja.github.io/compare/main...branchname`
+  - テンプレートを追加したURL
+    - `https://github.com/first-contributions-ja/first-contributions-ja.github.io/compare/main...branchname?quick_pull=1&template=pr.md`
 
 
 ## Branch

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -97,28 +97,20 @@
 - **作成ルール**
   - 基本的にDiscussionやDiscordで決まった新機能や、バグについてのみIssueを立てる
 - **作成手順**
-  - 各テンプレートに沿って内容を作成
-  - 未設定（後日追加予定）
-    - [新機能追加のテンプレート]()
-    - [バグ修正のテンプレート]()
+  - テンプレートに沿って内容を作成
+    - [テンプレート](https://github.com/first-contributions-ja/first-contributions-ja.github.io/blob/main/.github/ISSUE_TEMPLATE/%E3%82%A4%E3%82%B7%E3%83%A5%E3%83%BC%E3%83%86%E3%83%B3%E3%83%97%E3%83%AC%E3%83%BC%E3%83%88.md?plain=1)
+    - ~~[バグ修正用テンプレート]()~~ 必要があれば後日作成する
 - **Closeについて**
   - Issueに伴うブランチがマージされたらcloseすること（Pull Requestのコメントでcloseする）
 
 
 ## Pull Request
+- **作成ルール**
+  - 基本的にIssueに対してコードを作成し、プルリクエストを行う
+- **作成手順**
+  - テンプレートに沿って内容を作成
+    - [テンプレート](https://github.com/first-contributions-ja/first-contributions-ja.github.io/blob/main/.github/PULL_REQUEST_TEMPLATE%20/pr.md?plain=1)
 
-- 未設定（後日追加予定）
-  - [テンプレート]()
-
-**現状フォーマット**
-
-```markdown
-## 概要
-
-## 関連するIssue
-closed #issue番号
-```
-ref: [行動規範の作成 by kazzyfrog · Pull Request #14 · first-contributions-ja/first-contributions-ja](https://github.com/first-contributions-ja/first-contributions-ja/pull/14)
 
 ## Branch
 


### PR DESCRIPTION
## 概要
CONTRIBUTING.mdにイシュー・プルリクテンプレートのURLを入れる #28

## 関連するIssue
closed #28 

## その他
URLの追加の他に、プルリクの作成ルールを追加しました。
CONTRIBUTING.mdは参加者ではなくメンター向けのガイドなので、プルリクはイシューに対して行う旨を記載しました。問題がありましたら教えてください！

## 残課題
プルリク画面でのテンプレートの表示のさせ方がわからなかったので、そちらの方法については記載できませんでした。