### PR TITLE
metadataBaseでURLを設定

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,7 @@ const notojp = Noto_Sans_JP({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: {
     default: SITE_NAME,
     template: `%s - ${SITE_NAME}`,


### PR DESCRIPTION
<!-- 無理に以下の全てを埋める必要はありません🌟 -->

## 概要
<!-- 問題や目的についての、明確な説明 -->
layout.tsx内に記載されているmetadata内に、metadataBaseで、URLオブジェクトを設定しました！

経緯として、OGP・Twitter画像が正しく表示されていませんでした！

これは、Vercel以外にデプロイする場合、layout.tsx内に記載されている`metadata`内に、
`metadataBase`で、URLオブジェクトを設定しないと、デフォルトでOGPなどの画像のパスが`localhost:3000`になってしまうことが原因だと思われます！

## 関連するIssue
<!-- このPRに関連するイシューが既にある場合は、以下の「closed」の横にリンクしてください。
関連するイシューがない場合は、このPRが受け入れられる可能性が高くなるように、まずイシューを開くことをお勧めします。 -->

closed #138 


## その他
<!-- このPRに関する懸念点・アイデア・重点的にレビューして欲しいポイントを説明してください。
また、UIの変更などは動作確認用のスクリーンショットなどがあると、レビューがスムーズに行われます。 -->

[公式](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#default-value)より
> デフォルトをオーバーライドする場合は、環境変数を使用してURLを計算することをお勧めします。

環境変数を使用した方が良かったかもです！
現状では、ローカルと本番だけなので、問題ないと思われます！