### PR TITLE
Contributos.json 参加者人数をWebサイトに表示

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,14 +4,19 @@ export const BASE_PATH = basePath ? basePath : "";
 import GitHubIcon from "@mui/icons-material/GitHub";
 import { SITE_NAME } from "../../lib/constants";
 import KeyboardDoubleArrowDownSharpIcon from "@mui/icons-material/KeyboardDoubleArrowDownSharp";
+import contributors from "../../Contributors.json";
 
 export default function Home() {
+  const contributorsNumber = contributors.length;
+
   return (
     <>
       <section className="mx-auto mt-20 max-w-2xl px-6 lg:-mb-4 lg:mt-4 lg:flex lg:h-screen lg:max-w-7xl lg:items-center  lg:gap-10">
         <div className="lg:flex-1">
           <p className="hidden bg-stone-100 px-4 py-2 lg:inline-block">
-            <span className="text-2xl font-bold text-red-600">1234</span>
+            <span className="text-2xl font-bold text-red-600">
+              {contributorsNumber}
+            </span>
             人が参加中！
           </p>
           <div className="my-8 w-full lg:hidden">
@@ -51,7 +56,9 @@ export default function Home() {
           />
         </div>
         <p className="mx-auto mb-10 mt-5 rounded-sm bg-stone-100 px-4 py-2 text-center lg:hidden">
-          <span className="text-2xl font-bold text-red-600">1234</span>
+          <span className="text-2xl font-bold text-red-600">
+            {contributorsNumber}
+          </span>
           人が参加中！
         </p>
       </section>


### PR DESCRIPTION
<!-- 無理に以下の全てを埋める必要はありません🌟 -->

## 概要
<!-- 問題や目的についての、明確な説明 -->

- 仮の数字を入れていた参加者数をContributios.jsonから人数を取得、表示
- PC、SP変更済み

## 関連するIssue
<!-- このPRに関連するイシューが既にある場合は、以下の「closed」の横にリンクしてください。
関連するイシューがない場合は、このPRが受け入れられる可能性が高くなるように、まずイシューを開くことをお勧めします。 -->

closed #126


## その他
<!-- このPRに関する懸念点・アイデア・重点的にレビューして欲しいポイントを説明してください。
また、UIの変更などは動作確認用のスクリーンショットなどがあると、レビューがスムーズに行われます。 -->

![スクリーンショット 2024-03-29 22 20 47](https://github.com/first-contributions-ja/first-contributions-ja.github.io/assets/140990100/46bbe98e-0e2c-4688-b3ad-3bd7436840c5)

<img src="https://github.com/first-contributions-ja/first-contributions-ja.github.io/assets/140990100/4449ca66-cd0a-48a5-9de4-3eb6193b1749" width="400">


## 参考


## 残課題
<!-- やれていないこと、または作業中に発見した別の問題についての簡潔な説明。
別対応となる場合は、新たにイシューを作り#2の様に紐付けます。 -->
