### PR TITLE
Topページにコンセプトセクションを追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,7 @@ import {
   latestContributorsColor,
 } from "@/utils/contributors-grouping";
 import Button from "@/components/ui/button";
+import SectionTitle from "../components/ui/section-title";
 
 export default function Home() {
   const contributorsGroups = groupContributorsBySection(contributors, 3);
@@ -54,8 +55,25 @@ export default function Home() {
 
       <GradientBackground mainColor={latestContributorsColor}>
         <ScreenEmojis contributors={contributorsGroups[0]} isTopSection />
-        <section className="mx-auto h-screen max-w-screen-xl">
-          セクション1
+        <section className="mx-auto h-screen max-w-screen-lg px-4 py-32 text-center lg:px-20 lg:py-48">
+          <div className="relative">
+            <SectionTitle label="concept">
+              共同作業を実践し、GitHubに慣れる
+            </SectionTitle>
+            <p className="mt-8 text-gray-800 lg:text-lg lg:leading-loose">
+              GitやGitHubは、一人で学ぶのが難しいツールです。
+              <br />
+              バージョン管理やメッセージの書き方など、
+              <br />
+              個人での学習や開発ではその重要性を実感しにくいためです。
+              <br />
+              <br />
+              First Contributions
+              JAは、初学者向けに設計されたオープンなプロジェクトです。
+              <br />
+              チュートリアルに沿って、実際に共同開発を体験しながらGitHubを学べます！
+            </p>
+          </div>
         </section>
 
         <ScreenEmojis contributors={contributorsGroups[1]} />

--- a/src/components/ui/section-title.tsx
+++ b/src/components/ui/section-title.tsx
@@ -1,0 +1,16 @@
+interface SectionTitleProps {
+  label: string;
+  children: React.ReactNode;
+}
+function SectionTitle(props: SectionTitleProps) {
+  return (
+    <>
+      <p className="text-lg uppercase text-red-600">{props.label}</p>
+      <h2 className="mt-8 text-3xl font-bold leading-snug lg:text-5xl lg:leading-normal">
+        {props.children}
+      </h2>
+    </>
+  );
+}
+
+export default SectionTitle;


### PR DESCRIPTION
<!-- 無理に以下の全てを埋める必要はありません🌟 -->

## 概要
<!-- 問題や目的についての、明確な説明 -->
Topページに、コンセプトセクションを追加しました。
アニメーションの関係で、セクションを`h-screen`にしたかったので、結構デカデカと配置しています。
背景で絵文字が動いているので、見出しとかは大きめにした方が、ストレスなく読めるかと思った次第です！

また、デザインカンプでは、H2のテキストが
「実際の共同作業で、GitHubに慣れる」
でしたが、日本語が少しおかしいかも？と思ったので下記に変更しています！
「共同作業を実践し、GitHubに慣れる」

## 関連するIssue
<!-- このPRに関連するイシューが既にある場合は、以下の「closed」の横にリンクしてください。
関連するイシューがない場合は、このPRが受け入れられる可能性が高くなるように、まずイシューを開くことをお勧めします。 -->

closed #195


## その他
<!-- このPRに関する懸念点・アイデア・重点的にレビューして欲しいポイントを説明してください。
また、UIの変更などは動作確認用のスクリーンショットなどがあると、レビューがスムーズに行われます。 -->

セクションの最初に使う、赤文字のラベルとH2の見出しは、
繰り返し使うと思ったので、コンポーネントとして切り出しました

スタイルなどは、適宜変更しつつ、全セクションで統一して使えればと思ってます！

## 確認用スクリーンショット
![localhost_3000_ (2)](https://github.com/first-contributions-ja/first-contributions-ja.github.io/assets/70629747/a36a1308-7462-4bd6-9b98-b3dc5e095579)


<img width=300px src="https://github.com/first-contributions-ja/first-contributions-ja.github.io/assets/70629747/15f60949-938b-43d6-b1dc-d3beeef3c8fd">

