### PR TITLE
絵文字の表示の不具合を修正

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -43,7 +43,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ja">
+    <html lang="ja" className="overflow-x-hidden">
       <body
         className={`${inter.variable} ${notojp.variable} overflow-x-hidden text-stone-800`}
       >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,7 +26,7 @@ export default function Home() {
       <section className="relative h-screen overflow-hidden">
         <EmojiShower />
         <div className="absolute bottom-0 left-0 h-20 w-full bg-gradient-to-t from-white to-transparent"></div>
-        <div className="relative z-10 mx-auto flex h-full items-center justify-start lg:max-w-screen-xl">
+        <div className="relative mx-auto flex h-full items-center justify-start lg:max-w-screen-xl">
           <div className=" px-4 lg:px-0">
             <h1 className="text-4xl font-bold leading-snug lg:text-6xl lg:leading-normal">
               オープンソース

--- a/src/components/animated-emoji.tsx
+++ b/src/components/animated-emoji.tsx
@@ -30,7 +30,7 @@ const AnimatedEmoji: React.FC<AnimatedEmojiProps> = ({
   return (
     <>
       <div
-        className="group absolute -z-10 flex h-20 w-20 cursor-pointer items-center justify-center rounded-full bg-transparent [perspective:1000px]"
+        className="group absolute flex h-20 w-20 cursor-pointer items-center justify-center rounded-full bg-transparent [perspective:1000px]"
         style={styles as React.CSSProperties}
       >
         <div className="relative h-full w-full rounded-full duration-1000 [transform-style:preserve-3d] group-hover:[transform:rotateY(180deg)]">

--- a/src/components/hero-section-emoji-shower.tsx
+++ b/src/components/hero-section-emoji-shower.tsx
@@ -1,3 +1,4 @@
+import { emojiToUnicodeHex } from "@/utils/animated-emoji";
 import { Noto_Emoji } from "next/font/google";
 
 const emojiFont = Noto_Emoji({
@@ -112,15 +113,17 @@ const EmojiShower: React.FC = () => {
   return (
     <div className=" absolute -right-2 -top-8 z-0 flex h-[150vh] rotate-12 lg:-top-[15vh] lg:right-4 lg:rotate-[25deg]">
       {randomEmojis.map((emoji, index) => {
+        const notoEmoji = emojiToUnicodeHex(emoji);
         return (
           <div
             key={index}
             className={`${emojiFont.className} ${textRainbowColors[index]} ${bgRainbowColors[index]}
               px-1 text-3xl lg:px-2 lg:text-6xl`}
           >
-            <div className={`${animationsSp[index]} ${animationsPc[index]}`}>
-              {emoji}
-            </div>
+            <div
+              className={`${animationsSp[index]} ${animationsPc[index]}`}
+              dangerouslySetInnerHTML={{ __html: notoEmoji }}
+            ></div>
           </div>
         );
       })}


### PR DESCRIPTION
<!-- 無理に以下の全てを埋める必要はありません🌟 -->

## 概要
<!-- 問題や目的についての、明確な説明 -->
絵文字の表示の不具合を修正しました！
具体的には、
- コンセクトセクション以下の、絵文字のアニメーションに使っている、emojiToUnicodeHex()関数をヒーローセクションでも使用しました。
  - これで、HTMLを直接埋め込んでます！（dangerouslySetInnerHTML）
- また、z-indexに関しては、削除するだけでホバーの問題は解決できました！おそらく。。

## 関連するIssue
<!-- このPRに関連するイシューが既にある場合は、以下の「closed」の横にリンクしてください。
関連するイシューがない場合は、このPRが受け入れられる可能性が高くなるように、まずイシューを開くことをお勧めします。 -->

closed #208


## その他
<!-- このPRに関する懸念点・アイデア・重点的にレビューして欲しいポイントを説明してください。
また、UIの変更などは動作確認用のスクリーンショットなどがあると、レビューがスムーズに行われます。 -->

- [x] safariでも、noto emojiが表示されていることを確認しました！
- [x] コンセクトセクション以下の絵文字をホバーしたら、反転することも確認しました！
