### PR TITLE
現在のコントリビューター数を表示する、Thanks セクションの追加

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { SITE_NAME, SITE_URL, SITE_DESC } from "../../lib/constants";
-import { Inter, Noto_Sans_JP } from "next/font/google";
+import { Inter, Noto_Sans_JP, Noto_Color_Emoji } from "next/font/google";
 import "./globals.css";
 import Footer from "@/components/footer";
 import Header from "@/components/header";
@@ -13,6 +13,13 @@ const inter = Inter({
 const notojp = Noto_Sans_JP({
   preload: false,
   variable: "--font-notojp",
+});
+
+const emoji = Noto_Color_Emoji({
+  subsets: ["emoji"],
+  weight: "400",
+  display: "swap",
+  variable: "--font-noto-emoji",
 });
 
 export const metadata: Metadata = {
@@ -45,7 +52,7 @@ export default function RootLayout({
   return (
     <html lang="ja" className="overflow-x-hidden">
       <body
-        className={`${inter.variable} ${notojp.variable} overflow-x-hidden text-stone-800`}
+        className={`${inter.variable} ${notojp.variable} ${emoji.variable} overflow-x-hidden text-stone-800`}
       >
         <Header />
         {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,11 +16,12 @@ import SpeechBubbleItem from "@/components/ui/speechBubbleItem";
 import SpeechBubbleWrapper from "@/components/ui/SpeechBubbleWrapper";
 import Image from "next/image";
 import SectionTitle from "../components/ui/section-title";
+import { emojiToUnicodeHex } from "@/utils/animated-emoji";
 
 export default function Home() {
   const contributorsGroups = groupContributorsBySection(
     contributorsReversed,
-    3,
+    4,
   );
 
   return (
@@ -186,6 +187,55 @@ export default function Home() {
                 OSSコントリビューションは思ったより簡単なんだ✨
                 今すぐ参加します💨
               </p>
+            </SpeechBubbleItem>
+          </SpeechBubbleWrapper>
+        </section>
+
+        <ScreenEmojis contributors={contributorsGroups[3]} />
+        <section className="mx-auto flex h-screen max-w-screen-lg items-center px-4 lg:px-0">
+          <SpeechBubbleWrapper type="left">
+            <SpeechBubbleItem>
+              <div className="text-center">
+                <p className="inline-block bg-stone-100 px-4 py-2">
+                  <span className="text-2xl font-bold text-red-600">
+                    {contributorsReversed.length}
+                  </span>
+                  人が参加中！
+                </p>
+                <p className="text-4xl font-bold leading-snug lg:text-6xl lg:leading-normal">
+                  DOMO ARIGATO !!
+                </p>
+                <p
+                  className="text- mt-8 stroke-gray-500   font-notoEmoji text-9xl font-extrabold"
+                  style={{ color: latestContributorsColor }}
+                  dangerouslySetInnerHTML={{ __html: emojiToUnicodeHex("🎉") }}
+                ></p>
+              </div>
+            </SpeechBubbleItem>
+            <SpeechBubbleItem>
+              <p className="lg:mt-8">
+                First Contributions JAは、
+                <br className="lg:hidden" />
+                オープンなプロジェクトです。
+                <br />
+                そして、最高のコントリビューターに支えられています :)
+              </p>
+            </SpeechBubbleItem>
+            <SpeechBubbleItem>
+              <div className="flex flex-col items-center justify-center gap-4 lg:mt-8 lg:flex-row">
+                <Button className="w-full lg:w-40">
+                  <GitHubIcon className="text-2xl" />
+                  GitHub
+                </Button>
+                <Button
+                  type="outline"
+                  href={TWITTER_SHARE}
+                  className="w-full lg:w-40"
+                >
+                  <ShareIcon className="text-2xl" />
+                  Share
+                </Button>
+              </div>
             </SpeechBubbleItem>
           </SpeechBubbleWrapper>
         </section>

--- a/src/components/screen-emojis.tsx
+++ b/src/components/screen-emojis.tsx
@@ -1,12 +1,5 @@
 import AnimatedEmoji from "./animated-emoji";
 import contributorsReversed from "../utils/contributors-reversed";
-import { Noto_Emoji } from "next/font/google";
-
-const emoji = Noto_Emoji({
-  subsets: ["emoji"],
-  weight: "300",
-  display: "swap",
-});
 
 type ScreenEmojisProps = {
   contributors: typeof contributorsReversed;
@@ -19,7 +12,7 @@ const ScreenEmojis: React.FC<ScreenEmojisProps> = ({
 }) => {
   return (
     <>
-      <div className={`${emoji.className} relative`}>
+      <div className="relative font-notoEmoji">
         {contributors.map((contributor, index) => (
           <AnimatedEmoji
             key={index}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,3 @@
-import { transform } from "next/dist/build/swc";
 import type { Config } from "tailwindcss";
 
 const config: Config = {
@@ -9,7 +8,11 @@ const config: Config = {
     "./src/utils/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        notoEmoji: ["var(--font-noto-emoji)"],
+      },
+    },
     keyframes: {
       horizontal: {
         from: {


### PR DESCRIPTION
<!-- 無理に以下の全てを埋める必要はありません🌟 -->

## 概要
<!-- 問題や目的についての、明確な説明 -->
現在のコントリビューター数を表示する、Thanks セクションを追加しました！
（現在は、以下のスクリーンショットの状態です！）

加えて、以下の変更を行いました：
- 絵文字フォントを、Noto Color Emoji に変更
- src/components/screen-emojis.tsx にてインポートしていた絵文字のフォントを、上位の階層のlayout.tsxで読み込むよう変更
  - →tailwindのユーティリティクラスに記載し、全ページで使用できるように共通化

修正依頼も喜んで受け入れます🙌

また、もし他に、簡単な修正があれば、このPRでまとめてやってしまいますよ！
（もちろん別イシューにする形でもOKです！）

## 関連するIssue
<!-- このPRに関連するイシューが既にある場合は、以下の「closed」の横にリンクしてください。
関連するイシューがない場合は、このPRが受け入れられる可能性が高くなるように、まずイシューを開くことをお勧めします。 -->

closed #252


## その他
<!-- このPRに関する懸念点・アイデア・重点的にレビューして欲しいポイントを説明してください。
また、UIの変更などは動作確認用のスクリーンショットなどがあると、レビューがスムーズに行われます。 -->
現在のスクショ：

<img src="https://github.com/user-attachments/assets/2f13ba5e-0fea-41fa-925e-6d425742fdea" alt="v3_design_PCver" width="800px">  
<br />
<img src="https://github.com/user-attachments/assets/286900b5-f650-4d10-9cd0-250d171dd413" alt="v3_design_SPver" width="320px">

## 残課題
<!-- やれていないこと、または作業中に発見した別の問題についての簡潔な説明。
別対応となる場合は、新たにイシューを作り#2の様に紐付けます。 -->

- せっかくなので、変更する前のV2時点でのデザインをスクショして、[リリースノート](https://github.com/first-contributions-ja/first-contributions-ja.github.io/releases)に貼り付けていきました！（V1.0の時と同様に）