### PR TITLE
safariでの絵文字の不具合を修正

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,11 @@
 import type { Metadata } from "next";
 import { SITE_NAME, SITE_URL, SITE_DESC } from "../../lib/constants";
-import { Inter, Noto_Sans_JP, Noto_Color_Emoji } from "next/font/google";
+import {
+  Inter,
+  Noto_Sans_JP,
+  Noto_Color_Emoji,
+  Noto_Emoji,
+} from "next/font/google";
 import "./globals.css";
 import Footer from "@/components/footer";
 import Header from "@/components/header";
@@ -15,7 +20,14 @@ const notojp = Noto_Sans_JP({
   variable: "--font-notojp",
 });
 
-const emoji = Noto_Color_Emoji({
+const notoColorEmoji = Noto_Color_Emoji({
+  subsets: ["emoji"],
+  weight: "400",
+  display: "swap",
+  variable: "--font-noto-color-emoji",
+});
+
+const notoEmoji = Noto_Emoji({
   subsets: ["emoji"],
   weight: "400",
   display: "swap",
@@ -52,7 +64,7 @@ export default function RootLayout({
   return (
     <html lang="ja" className="overflow-x-hidden">
       <body
-        className={`${inter.variable} ${notojp.variable} ${emoji.variable} overflow-x-hidden text-stone-800`}
+        className={`${inter.variable} ${notojp.variable} ${notoEmoji.variable} ${notoColorEmoji.variable} overflow-x-hidden text-stone-800`}
       >
         <Header />
         {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -207,7 +207,7 @@ export default function Home() {
                   ARIGATO !!
                 </p>
                 <p
-                  className="mb-2 mt-8 stroke-gray-500 font-notoEmoji text-9xl"
+                  className="mb-2 mt-8 font-notoEmoji text-9xl text-red-600"
                   dangerouslySetInnerHTML={{ __html: emojiToUnicodeHex("🎉") }}
                 ></p>
               </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -208,7 +208,6 @@ export default function Home() {
                 </p>
                 <p
                   className="mb-2 mt-8 stroke-gray-500 font-notoEmoji text-9xl"
-                  style={{ color: latestContributorsColor }}
                   dangerouslySetInnerHTML={{ __html: emojiToUnicodeHex("🎉") }}
                 ></p>
               </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,7 +10,7 @@ const config: Config = {
   theme: {
     extend: {
       fontFamily: {
-        notoEmoji: ["var(--font-noto-emoji)"],
+        notoEmoji: ["var(--font-noto-color-emoji), var(--font-noto-emoji)"],
       },
     },
     keyframes: {


### PR DESCRIPTION
<!-- 無理に以下の全てを埋める必要はありません🌟 -->

## 概要
<!-- 問題や目的についての、明確な説明 -->
safariにて、カラー絵文字がうまく適応されず、空白になってしまっていました。

なので、２つ目の絵文字に、以前のモノクロのNoto Emojiを設定し、
１つ目が無理なら２つ目にフォールバックするように修正しました！

これによって、以下が適応されるかと思います！
- Chromeでは、１つ目のカラー絵文字
- Mac/ safariでは、２つ目のモノクロのNoto絵文字

## 関連するIssue
<!-- このPRに関連するイシューが既にある場合は、以下の「closed」の横にリンクしてください。
関連するイシューがない場合は、このPRが受け入れられる可能性が高くなるように、まずイシューを開くことをお勧めします。 -->

closed #257


## その他
<!-- このPRに関する懸念点・アイデア・重点的にレビューして欲しいポイントを説明してください。
また、UIの変更などは動作確認用のスクリーンショットなどがあると、レビューがスムーズに行われます。 -->

一時的な解決策ですが、safaiからのアクセスするユーザーが、
絵文字が見えない状態を避けるために、対応しました！

この問題に関する、別のアイデア・修正依頼も喜んで受け入れます🙌