### PR TITLE
サイト上の色を変えるためkazzyfrogの情報を更新

### DIFF
--- a/Contributors.json
+++ b/Contributors.json
@@ -12,12 +12,6 @@
     "favoriteEmoji": "🌀"
   },
   {
-    "name": "kazzyfrog",
-    "github": "https://github.com/kazzyfrog",
-    "favoriteColor": "#98fb98",
-    "favoriteEmoji": "🐸"
-  },
-  {
     "name": "oginochihiro",
     "github": "https://github.com/first-contributions-ja",
     "favoriteColor": "#ffffff",
@@ -238,5 +232,11 @@
     "github": "https://github.com/dws2020",
     "favoriteColor": "#ffffff",
     "favoriteEmoji": "🐼"
+  },
+  {
+    "name": "kazzyfrog",
+    "github": "https://github.com/kazzyfrog",
+    "favoriteColor": "#C6BA9F",
+    "favoriteEmoji": "🐸"
   }
 ]


### PR DESCRIPTION
<!-- 無理に以下の全てを埋める必要はありません🌟 -->

## 概要
<!-- 問題や目的についての、明確な説明 -->
サイト上の色（背景色と、絵文字の色）を変えるため、情報を更新しました！

現状、最新のコントリビューターの好きな色が白（#fff）のため、
safariでは、[その他]のスクリーンショットのような表示になっています。

Chromeでは、Noto Color Emoji が表示されるので、絵文字は見えますが、
safariでは、絵文字が見えない状態です。

## その他
<!-- このPRに関する懸念点・アイデア・重点的にレビューして欲しいポイントを説明してください。
また、UIの変更などは動作確認用のスクリーンショットなどがあると、レビューがスムーズに行われます。 -->
<img width="1418" alt="スクリーンショット 2024-08-16 18 48 38" src="https://github.com/user-attachments/assets/bd0a2012-e704-493c-abde-4dd19e3e27f4">

## 残課題
<!-- やれていないこと、または作業中に発見した別の問題についての簡潔な説明。
別対応となる場合は、新たにイシューを作り#2の様に紐付けます。 -->

こちら１時的な解決策のため、
好きな色が白（#fff）、もしくはそれに近い色の場合に、safariで絵文字と背景デザインが見えなくなってしまう問題に対して、
良い対処法があるか、少し考えてみます👍
