### PR TITLE
🎨 style: サイト上の色を変えるためkazzyfrogの情報を更新

### DIFF
--- a/Contributors.json
+++ b/Contributors.json
@@ -234,12 +234,6 @@
     "favoriteEmoji": "🐼"
   },
   {
-    "name": "kazzyfrog",
-    "github": "https://github.com/kazzyfrog",
-    "favoriteColor": "#C6BA9F",
-    "favoriteEmoji": "🐸"
-  },
-  {
     "name": "aki-tkcy",
     "github": "https://github.com/aki-tkcy",
     "favoriteColor": "#3BD5C3",
@@ -310,5 +304,11 @@
     "github": "https://github.com/sademban",
     "favoriteColor": "#FFFFFF",
     "favoriteEmoji": "🤪"
+  },
+  {
+    "name": "kazzyfrog",
+    "github": "https://github.com/kazzyfrog",
+    "favoriteColor": "#ddcfb1",
+    "favoriteEmoji": "🐸"
   }
 ]


### PR DESCRIPTION
## 概要

サイト上の色（背景色と、絵文字の色）を変えるため、情報を更新しました！

現状、最新のコントリビューターの好きな色が白（#fff）のため、
Chromeでは、Noto Color Emoji が表示されるので、絵文字は見えますが、
safariでは、絵文字が見えない状態です。

- #301 

これは、上記にて着手しますが、１時的に、サイト上を修正します。