### PR TITLE
safariでの表示崩れ防止のため、デフォルトの背景色を指定

### DIFF
--- a/src/utils/contributors-grouping.ts
+++ b/src/utils/contributors-grouping.ts
@@ -1,5 +1,14 @@
 import contributorsReversed from "../utils/contributors-reversed";
-const latestContributorsColor = contributorsReversed[0].favoriteColor;
+
+// デフォルトの背景色(特に理由はないので変更可)
+const DEFAULT_BACKGROUND_COLOR = "#C6BA9F";
+
+// FFF（白）の場合、safariで背景と絵文字が見えなくなるので、デフォルトを適用
+const latestContributorsColor =
+  contributorsReversed[0].favoriteColor.toLowerCase() === "#ffffff"
+    ? DEFAULT_BACKGROUND_COLOR
+    : contributorsReversed[0].favoriteColor;
+
 type contributor = typeof contributorsReversed;
 
 const SECTION_SIZE = 10;


### PR DESCRIPTION
## 関連イシュー

- #301 

## 概要

イシューの通りですが、
現在、好きな色が白（#fff）、もしくはそれに近い色を指定したら、safariで絵文字と背景デザインが見えなくなってしまいます。

何で、白（#fff）の場合は、デフォルトの色に置き換えるように修正しました。
デフォルトの色は、現状ランダムにベージュに設定していますが、これはなんでも良い色なので、変更可能です！

上記以外で、白に近い色で背景・絵文字が見えない場合は、手動で変更するなどで対応しますー🐱🐱